### PR TITLE
INACTIVE CLOSE BUTTON HIDDEN FROM SERIES PAGE

### DIFF
--- a/stylesheets/docs.css
+++ b/stylesheets/docs.css
@@ -2359,3 +2359,8 @@ code .chunk {
   }
 
 }
+
+/* Removing inactive close button in series pages */
+#example .pusher .ui.message>.close.icon {
+	display:none;
+}


### PR DESCRIPTION
Done by adding a display:none to docs.css
!important not added as of now